### PR TITLE
fix: environment variable check in doctor module

### DIFF
--- a/cli/cargo-ohrs/src/doctor/mod.rs
+++ b/cli/cargo-ohrs/src/doctor/mod.rs
@@ -17,7 +17,7 @@ pub fn doctor() -> anyhow::Result<()> {
 
   let msvc = Version::parse("1.78.0")?;
 
-  let is_env_ok = ndk.is_empty();
+  let is_env_ok = !ndk.is_empty();
   println!(
     "{}  Environment variable {} should be set.",
     render(is_env_ok),


### PR DESCRIPTION
When comparing ndk, it should be non-empty check