### PR TITLE
Fix: Link against `ace_napi.z` inline

### DIFF
--- a/crates/sys/src/lib.rs
+++ b/crates/sys/src/lib.rs
@@ -103,3 +103,7 @@ pub unsafe fn setup() -> libloading::Library {
     Ok(l) => l,
   }
 }
+
+/// On OpenHarmony we need to link against `ace_napi.z`.
+#[cfg_attr(target_env = "ohos", link(name = "ace_napi.z"))]
+extern "C" {}


### PR DESCRIPTION
This allows use `napi-ohos` without a build script.