### PR TITLE
fix(build): Improve error message on absolute path conversion failure

### DIFF
--- a/cli/cargo-ohrs/src/build/artifact.rs
+++ b/cli/cargo-ohrs/src/build/artifact.rs
@@ -33,16 +33,17 @@ pub fn resolve_dependence_library(script: BuildScript, ndk: String) -> Option<Ve
           return None;
         }
         if item_path.starts_with("native=") {
+
           return Some(
             PathBuf::from(&item_path[7..])
               .canonicalize()
-              .expect("Convert to absolute path failed."),
+              .expect(&format!("Convert {} to absolute path failed.", item_path)),
           );
         }
         if is_rust_intermediate_lib(&i) {
           return None;
         }
-        let current_path = i.canonicalize().expect("Convert to absolute path failed.");
+        let current_path = i.canonicalize().expect(&format!("Convert {} to absolute path failed.", i.as_str()));
         if !i.is_dir() && !i.is_file() {
           println!("Note: {} is not a dir or file.", i.as_str());
           return None;


### PR DESCRIPTION
Add a more detailed error that includes the specific path that failed to convert to an absolute path.